### PR TITLE
Fix QueryHistory NPE when queryids missing

### DIFF
--- a/src/main/java/yanagishima/controller/QueryHistoryController.java
+++ b/src/main/java/yanagishima/controller/QueryHistoryController.java
@@ -33,7 +33,7 @@ public class QueryHistoryController {
                                  @RequestParam(required = false) String queryids) {
     Map<String, Object> responseBody = new HashMap<>();
     try {
-      String[] queryIds = queryids.split(","); // TODO: Fix NPE
+      String[] queryIds = (queryids == null || queryids.isEmpty()) ? new String[0] : queryids.split(",");
       responseBody.put("headers", Arrays
           .asList("Id", "Query", "Time", "rawDataSize", "engine", "finishedTime", "linenumber", "status"));
       responseBody.put("results", getHistories(datasource, queryIds));
@@ -54,6 +54,9 @@ public class QueryHistoryController {
   }
 
   private List<Query> getQueries(String datasource, String[] queryIds) {
+    if (queryIds.length == 0) {
+      return List.of();
+    }
     return queryService.getAll(datasource, Lists.newArrayList(queryIds));
   }
 

--- a/src/test/java/yanagishima/controller/QueryHistoryControllerTest.java
+++ b/src/test/java/yanagishima/controller/QueryHistoryControllerTest.java
@@ -1,0 +1,42 @@
+package yanagishima.controller;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import yanagishima.service.QueryService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class QueryHistoryControllerTest {
+  private static final String QUERY_HISTORY = "/queryHistory";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private QueryService queryService;
+
+  @Test
+  void getWithoutQueryIds() throws Exception {
+    when(queryService.getAll(anyString(), anyList())).thenReturn(Collections.emptyList());
+
+    mockMvc
+        .perform(get(QUERY_HISTORY)
+                     .param("datasource", "test-datasource"))
+        .andDo(print())
+        .andExpect(status().isOk());
+  }
+}


### PR DESCRIPTION
## Summary
- avoid NPE in `QueryHistoryController` when `queryids` is not provided
- short circuit query lookup when there are no ids
- test `QueryHistoryController` handling of missing `queryids`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ed5885c6c832ab0051e5a6054b0cf