### PR TITLE
Handle blank query IDs

### DIFF
--- a/src/main/java/yanagishima/controller/QueryHistoryController.java
+++ b/src/main/java/yanagishima/controller/QueryHistoryController.java
@@ -33,9 +33,15 @@ public class QueryHistoryController {
                                  @RequestParam(required = false) String queryids) {
     Map<String, Object> responseBody = new HashMap<>();
     try {
-      String[] queryIds = queryids.split(","); // TODO: Fix NPE
       responseBody.put("headers", Arrays
           .asList("Id", "Query", "Time", "rawDataSize", "engine", "finishedTime", "linenumber", "status"));
+
+      if (queryids == null || queryids.isBlank()) {
+        responseBody.put("results", List.of());
+        return responseBody;
+      }
+
+      String[] queryIds = queryids.split(",");
       responseBody.put("results", getHistories(datasource, queryIds));
 
     } catch (Throwable e) {

--- a/src/test/java/yanagishima/controller/QueryHistoryControllerTest.java
+++ b/src/test/java/yanagishima/controller/QueryHistoryControllerTest.java
@@ -1,0 +1,34 @@
+package yanagishima.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import yanagishima.service.QueryService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class QueryHistoryControllerTest {
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  private QueryService queryService;
+
+  @Test
+  void getWithoutQueryIdsReturnsEmptyResult() throws Exception {
+    mockMvc.perform(get("/queryHistory")
+                       .param("datasource", "test"))
+           .andDo(print())
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.results").isArray())
+           .andExpect(jsonPath("$.results").isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary
- avoid splitting query IDs when parameter is null or blank
- return empty results when query IDs are omitted
- test `QueryHistoryController` for missing IDs

## Testing
- `gradle test --tests yanagishima.controller.QueryHistoryControllerTest -q` *(fails: Plugin net.ltgt.errorprone not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed8f96294832ab1a3c4e14af1ccca