### PR TITLE
Display logged-in user in header

### DIFF
--- a/web/src/components/TheHeaderUpper.vue
+++ b/web/src/components/TheHeaderUpper.vue
@@ -46,6 +46,7 @@
           <a href="#auth" class="text-white mr-2" data-toggle="modal" data-target="#auth">
             <i v-if="authUser" class="fas fa-lg fa-user"></i>
             <i v-else class="fas fa-lg fa-user-times"></i>
+            <span v-if="authUser" class="small ml-1">{{ authUser }}</span>
           </a>
         </template>
         <div class="dropdown d-inline-block mr-2">


### PR DESCRIPTION
## Summary
- show `authUser` in `TheHeaderUpper.vue` when available
- attempted to rebuild frontend via `web/deploy.sh` (fails offline)

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `web/deploy.sh` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685ee6f384ac832ab348ed691895868d