### PR TITLE
Switch to Presto only config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,12 +128,12 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.14.9'
 
     // Spark
-    implementation 'org.apache.httpcomponents:fluent-hc:4.5.13'
-    implementation 'org.jsoup:jsoup:1.11.3'
+    // implementation 'org.apache.httpcomponents:fluent-hc:4.5.13'
+    // implementation 'org.jsoup:jsoup:1.11.3'
 
     // Hive
-    implementation 'org.apache.hive:hive-jdbc:1.2.1000.2.5.3.0-37'
-    implementation 'org.apache.hadoop:hadoop-common:2.7.3.2.5.3.0-37'
+    // implementation 'org.apache.hive:hive-jdbc:1.2.1000.2.5.3.0-37'
+    // implementation 'org.apache.hadoop:hadoop-common:2.7.3.2.5.3.0-37'
 
     // Fluentd
     implementation 'org.komamitsu:fluency:1.7.0'

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,6 +1,8 @@
 # Configuration
 Spring Boot is used as a main framework and MySQL instance is required. See [official documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto.data-access) to configure the datasource.
 
+This guide focuses on a single Trino setup and removes options for other engines.
+
 You need to edit `application.yml` file.
 ```yaml
 # yanagishima web port
@@ -33,21 +35,9 @@ audit.http.header.name: some.auth.header
 to.values.query.limit: 500
 # authorization feature
 check.datasource: false
-hive.jdbc.url.your-hive: jdbc:hive2://localhost:10000/default;auth=noSasl
-hive.jdbc.user.your-hive: yanagishima-hive
-hive.jdbc.password.your-hive: yanagishima-hive
-hive.query.max-run-time-seconds: 3600
-hive.query.max-run-time-seconds.your-hive: 3600
-resource.manager.url.your-hive: http://localhost:8088
-sql.query.engines: presto,hive
-hive.datasources: your-hive
-hive.disallowed.keywords.your-hive: insert,drop
-# 1GB. If hive query result file size exceeds this value, yanagishima cancel the query.
-hive.max-result-file-byte-size: 1073741824
-# setup initial hive query(for example, set hive.mapred.mode=strict)
-hive.setup.query.path.your-hive: /usr/local/yanagishima/conf/hive_setup_query_your-hive
 # CORS setting
 cors.enabled: false
+sql.query.engines: presto
 ```
 
 ## Single Trino cluster
@@ -59,68 +49,4 @@ presto.redirect.server.your-presto: http://presto.coordinator:8080/ui
 catalog.your-presto: hive
 schema.your-presto: default
 sql.query.engines: presto
-```
-
-## Multiple Trino clusters
-```yaml
-server.port: 8080
-presto.datasources: presto1,presto2
-presto.coordinator.server.presto1: http://presto1.coordinator:8080
-presto.redirect.server.presto1: http://presto1.coordinator:8080/ui
-presto.coordinator.server.presto2: http://presto2.coordinator:8080
-presto.redirect.server.presto2: http://presto2.coordinator:8080/ui
-catalog.presto1: hive
-schema.presto1: default
-catalog.presto2: hive
-schema.presto2: default
-sql.query.engines: presto
-```
-
-## Single Hive cluster
-```yaml
-server.port: 8080
-hive.jdbc.url.your-hive: jdbc:hive2://localhost:10000/default;auth=noSasl
-hive.jdbc.user.your-hive: yanagishima-hive
-hive.jdbc.password.your-hive: yanagishima-hive
-resource.manager.url.your-hive: http://localhost:8088
-sql.query.engines: hive
-hive.datasources: your-hive
-```
-
-## Kerberized Hive cluster
-```yaml
-server.port: 8080
-hive.jdbc.url.your-hive: jdbc:hive2://localhost:10000/default;auth=noSasl
-hive.jdbc.user.your-hive: yanagishima-hive
-hive.jdbc.password.your-hive: yanagishima-hive
-resource.manager.url.your-hive: http://localhost:8088
-sql.query.engines: hive
-hive.datasources: your-hive
-use.jdbc.cancel.your-hive: true
-```
-
-## Trino and Hive
-```yaml
-server.port: 8080
-presto.datasources: your-cluster
-presto.coordinator.server.your-cluster: http://presto.coordinator:8080
-presto.redirect.server.your-cluster: http://presto.coordinator:8080/ui
-catalog.your-cluster: hive
-schema.your-cluster: default
-hive.jdbc.url.your-cluster: jdbc:hive2://localhost:10000/default;auth=noSasl
-hive.jdbc.user.your-cluster: yanagishima-hive
-hive.jdbc.password.your-cluster: yanagishima-hive
-resource.manager.url.your-cluster: http://localhost:8088
-sql.query.engines: presto,hive
-hive.datasources: your-cluster
-```
-
-## Spark
-```yaml
-server.port: 8080
-spark.jdbc.url.your-spark: jdbc:hive2://sparkthriftserver:10000
-spark.web.url.your-spark: http://sparkthriftserver:4040
-resource.manager.url.your-hive: http://localhost:8088
-sql.query.engines: spark
-spark.datasources: your-spark
 ```

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -34,7 +34,7 @@ management:
     web.exposure.include: '*'
 
 # Datasources
-sql.query.engines: presto,hive,spark
+sql.query.engines: presto
 check.datasource: false
 select.limit: 500
 audit.http.header.name: some.auth.header
@@ -52,18 +52,18 @@ presto.redirect.server.docker-presto: http://localhost:18080/ui
 catalog.docker-presto: tpch
 schema.docker-presto: sf1
 
-# Hive
-hive.datasources: docker-hive
-hive.jdbc.url.docker-hive: jdbc:hive2://localhost:10000/default
-hive.jdbc.user.docker-hive: yanagishima
-hive.jdbc.password.docker-hive: yanagishima
-hive.query.max-run-time-seconds: 3600
-hive.query.max-run-time-seconds.docker-hive: 3600
-resource.manager.url.docker-hive: http://localhost:8088
-hive.max-result-file-byte-size: 1073741824
+## Hive
+# hive.datasources: docker-hive
+# hive.jdbc.url.docker-hive: jdbc:hive2://localhost:10000/default
+# hive.jdbc.user.docker-hive: yanagishima
+# hive.jdbc.password.docker-hive: yanagishima
+# hive.query.max-run-time-seconds: 3600
+# hive.query.max-run-time-seconds.docker-hive: 3600
+# resource.manager.url.docker-hive: http://localhost:8088
+# hive.max-result-file-byte-size: 1073741824
 
-# Spark
-spark.datasources: docker-spark
-spark.jdbc.url.docker-spark: jdbc:hive2://localhost:10001
-spark.web.url.docker-spark: http://localhost:14040
-resource.manager.url.docker-spark: http://localhost:18088
+## Spark
+# spark.datasources: docker-spark
+# spark.jdbc.url.docker-spark: jdbc:hive2://localhost:10001
+# spark.web.url.docker-spark: http://localhost:14040
+# resource.manager.url.docker-spark: http://localhost:18088


### PR DESCRIPTION
## Summary
- set `sql.query.engines` to Presto only
- comment out Hive and Spark sections in `application.yml`
- drop Hive and Spark dependencies from `build.gradle`
- trim configuration docs to describe a single Trino setup

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ee6f6b88c832a8afd48c47e0380cc