### PR TITLE
Fix frontend build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ task createDirs() {
 
 task buildWeb(type:Exec) {
     workingDir './web'
-    commandLine './deploy.sh'
+    commandLine 'bash', '-c', 'npm install && npm run build'
     standardOutput = new ByteArrayOutputStream()
     ext.output = {
         return standardOutput.toString()


### PR DESCRIPTION
## Summary
- npm build web frontend when running `gradlew`

## Testing
- `./gradlew test` *(fails: Execution failed for task ':compileJava')*

------
https://chatgpt.com/codex/tasks/task_e_685f161e1af4832a84483b21ab6f8578